### PR TITLE
ci(semantic-versioning): added a secret key and changed the variable …

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,3 +1,8 @@
+permissions:
+  contents: write
+  issues: write
+  packages: write
+
 name: Version and Release Notes
 
 on:
@@ -24,5 +29,5 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SEMANTIC_VERSIONING_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/versioning.yml` file to improve the versioning workflow permissions and environment variables.

Improvements to versioning workflow:

* Added write permissions for `contents`, `issues`, and `packages` in the `permissions` section.
* Changed the `GH_TOKEN` environment variable from `secrets.GITHUB_TOKEN` to `secrets.SEMANTIC_VERSIONING_TOKEN` in the `Run semantic-release` job