### PR TITLE
ci(token): adjusted the github token

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GH_TOKEN: ${{ secrets.SEMANTIC_VERSIONING_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/versioning.yml` file. The change updates the environment variable used for the GitHub token in the `Run semantic-release` job.

* [`.github/workflows/versioning.yml`](diffhunk://#diff-a939aacba1dba4141eda9eda616ff5e54462b324fbaebe0f8848c06964e67c68L34-R34): Changed `GH_TOKEN` from `${{ secrets.SEMANTIC_VERSIONING_TOKEN }}` to `${{ secrets.GITHUB_TOKEN }}`.