### PR TITLE
ci(versioning): adjusted the versioning

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          token: '${{ secrets.GITHUB_TOKEN }}'
 
       - name: Setup Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/versioning.yml` file. The change adds the GitHub token to the checkout step to ensure proper authentication.

* [`.github/workflows/versioning.yml`](diffhunk://#diff-a939aacba1dba4141eda9eda616ff5e54462b324fbaebe0f8848c06964e67c68R23-R24): Added `token: '${{ secrets.GITHUB_TOKEN }}'` to the checkout step to enable repository access during workflow execution.